### PR TITLE
Add detailed direction mode

### DIFF
--- a/src/main/java/com/roverisadog/infohud/CommandExecutor.java
+++ b/src/main/java/com/roverisadog/infohud/CommandExecutor.java
@@ -19,7 +19,7 @@ public class CommandExecutor implements TabExecutor {
 	static final String CMD_NAME = "infohud";
 	/** Commands available for normal users. */
 	private static final List<String> CMD_NORMAL =
-			Arrays.asList("enable", "disable", CoordMode.cmdName, TimeMode.cmdName, DarkMode.cmdName, "help");
+			Arrays.asList("enable", "disable", CoordMode.cmdName, DirectionMode.cmdName, TimeMode.cmdName, DarkMode.cmdName, "help");
 	/** Commands available exclusively to admins. */
 	private static final List<String> CMD_ADMIN =
 			Arrays.asList("messageUpdateDelay", "reload", "benchmark", "brightBiomes");
@@ -105,7 +105,7 @@ public class CommandExecutor implements TabExecutor {
 			int currentLevel = 1;
 
 			// [/infohud help]
-			if (argument1.equalsIgnoreCase(CMD_NORMAL.get(5))) {
+			if (argument1.equalsIgnoreCase(CMD_NORMAL.get(6))) {
 				buildAndSendHelpMenu(sender);
 			}
 
@@ -140,6 +140,10 @@ public class CommandExecutor implements TabExecutor {
 					// [/infohud coordinates]
 					else if (argument1.equalsIgnoreCase(CoordMode.cmdName)) {
 						changeCoordMode(p, args, currentLevel);
+					}
+					// [/infohud direction]
+					else if (argument1.equalsIgnoreCase(DirectionMode.cmdName)) {
+						changeDirectionMode(p, args, currentLevel);
 					}
 					// [/infohud time]
 					else if (argument1.equalsIgnoreCase(TimeMode.cmdName)) {
@@ -227,6 +231,10 @@ public class CommandExecutor implements TabExecutor {
 				if (argument1.equalsIgnoreCase(CoordMode.cmdName)) {
 					return StringUtil.copyPartialMatches(argument2, CoordMode.OPTIONS_LIST, new ArrayList<>());
 				}
+				//"direction"
+				else if (argument1.equalsIgnoreCase(DirectionMode.cmdName)) {
+					return StringUtil.copyPartialMatches(argument2, DirectionMode.OPTIONS_LIST, new ArrayList<>());
+				}
 				//"time"
 				else if (argument1.equalsIgnoreCase(TimeMode.cmdName)) {
 					return StringUtil.copyPartialMatches(argument2, TimeMode.OPTIONS_LIST, new ArrayList<>());
@@ -303,6 +311,35 @@ public class CommandExecutor implements TabExecutor {
 		// Unrecognised argument
 		Util.sendMsg(p, "Usage: " + Util.HLT + "'/" +
 				CMD_NAME + " " + CoordMode.cmdName + " " + Arrays.toString(CoordMode.values()));
+	}
+
+	/**
+	 * Changes the direction mode of a player.
+	 * @param p Concerned player.
+	 * @param args Arguments list.
+	 * @param argStart Commands before argStart have been consumed.
+	 */
+	private void changeDirectionMode(Player p, String[] args, int argStart) {
+		// No argument
+		if (args.length < argStart + 1) {
+			Util.sendMsg(p, "Direction display is currently set to: " + Util.HLT + pluginInstance.getConfigManager().getDirectionMode(p));
+			return;
+		}
+
+		//Cycle through all direction modes
+		for (DirectionMode dm : DirectionMode.values()) {
+			if (dm.name.equalsIgnoreCase(args[argStart])) {
+				if (pluginInstance.getConfigManager().setDirectionMode(p, dm))
+					Util.sendMsg(p, "Direction display set to: " + Util.HLT + dm.description + Util.RES + ".");
+				else
+					Util.sendMsg(p, Util.ERR + "Error while changing direction display mode");
+				return;
+			}
+		}
+
+		// Unrecognised argument
+		Util.sendMsg(p, "Usage: " + Util.HLT + "'/" +
+				CMD_NAME + " " + DirectionMode.cmdName + " " + Arrays.toString(DirectionMode.values()));
 	}
 
 	/**
@@ -566,6 +603,7 @@ public class CommandExecutor implements TabExecutor {
 			if (pluginInstance.getConfigManager().isEnabled(p)) {
 				PlayerCfg cfg = pluginInstance.getConfigManager().getCfg(p);
 				msg.add(Util.HLT + "   coordinates: " + Util.RES + cfg.getCoordMode().description);
+				msg.add(Util.HLT + "   direction: " + Util.RES + cfg.getDirectionMode().description);
 				msg.add(Util.HLT + "   time: " + Util.RES + cfg.getTimeMode().description);
 				msg.add(Util.HLT + "   darkMode: " + Util.RES + cfg.getDarkMode().description);
 			}
@@ -576,6 +614,7 @@ public class CommandExecutor implements TabExecutor {
 		msg.add(Util.GRN + "Settings");
 		if (sender instanceof Player) {
 			msg.add(Util.HLT + ">coordinates: " + Util.RES + "Enable/Disable coordinates display.");
+			msg.add(Util.HLT + ">direction: " + Util.RES + "Enable/Disable direction display.");
 			msg.add(Util.HLT + ">time: " + Util.RES + "Time display format (or disable).");
 			msg.add(Util.HLT + ">darkMode: " + Util.RES + "Enable/Disable/Auto using lighter colors.");
 		}

--- a/src/main/java/com/roverisadog/infohud/MessageUpdaterTask.java
+++ b/src/main/java/com/roverisadog/infohud/MessageUpdaterTask.java
@@ -1,5 +1,7 @@
 package com.roverisadog.infohud;
 
+import java.util.*;
+
 import com.roverisadog.infohud.config.*;
 import com.roverisadog.infohud.message.ActionBarSender;
 import org.bukkit.Bukkit;
@@ -83,59 +85,29 @@ public class MessageUpdaterTask implements Runnable {
 				color2 = dark2;
 			}
 
-			//Coordinates enabled
+			List<String> fields = new ArrayList<>();
 			if (cfg.getCoordMode() == CoordMode.ENABLED) {
-				switch (cfg.getTimeMode()) {
-					case DISABLED:
-						sendToActionBar(p, color1 + "XYZ: "
-								+ color2 + CoordMode.getCoordinates(p) + " "
-								+ color1 + getPlayerDirection(p));
-						break;
-					case CURRENT_TICK:
-						sendToActionBar(p, color1 + "XYZ: "
-								+ color2 + CoordMode.getCoordinates(p) + " "
-								+ color1 + String.format("%-10s", getPlayerDirection(p))
-								+ color2 + TimeMode.getTimeTicks(p));
-						break;
-					case CLOCK24:
-						sendToActionBar(p, color1 + "XYZ: "
-								+ color2 + CoordMode.getCoordinates(p) + " "
-								+ color1 + String.format("%-10s", getPlayerDirection(p))
-								+ color2 + TimeMode.getTime24(p));
-						break;
-					case CLOCK12:
-						sendToActionBar(p, color1 + "XYZ: "
-								+ color2 + CoordMode.getCoordinates(p) + " "
-								+ color1 + String.format("%-10s", getPlayerDirection(p))
-								+ color2 + TimeMode.getTime12(p, color1, color2));
-						break;
-					case VILLAGER_SCHEDULE:
-						sendToActionBar(p, color1 + "XYZ: "
-								+ color2 + CoordMode.getCoordinates(p) + " "
-								+ color1 + String.format("%-10s", getPlayerDirection(p))
-								+ color2 + TimeMode.getVillagerTime(p, color1, color2));
-						break;
-					default: //Ignored
-				}
+				fields.add(color1 + "XYZ: " + color2 + CoordMode.getCoordinates(p));
+				fields.add(color1 + String.format("%-10s", getPlayerDirection(p)));
+			}
+			switch (cfg.getTimeMode()) {
+				case CURRENT_TICK:
+					fields.add(color2 + TimeMode.getTimeTicks(p));
+					break;
+				case CLOCK24:
+					fields.add(color2 + TimeMode.getTime24(p));
+					break;
+				case CLOCK12:
+					fields.add(color2 + TimeMode.getTime12(p, color1, color2));
+					break;
+				case VILLAGER_SCHEDULE:
+					fields.add(color2 + TimeMode.getVillagerTime(p, color1, color2));
+					break;
 			}
 
-			//Coordinates disabled
-			else if (cfg.getCoordMode() == CoordMode.DISABLED) {
-				switch (cfg.getTimeMode()) {
-					case CURRENT_TICK:
-						sendToActionBar(p, color2 + TimeMode.getTimeTicks(p));
-						break;
-					case CLOCK12:
-						sendToActionBar(p, color2 + TimeMode.getTime12(p, color1, color2));
-						break;
-					case CLOCK24:
-						sendToActionBar(p, color2 + TimeMode.getTime24(p));
-						break;
-					case VILLAGER_SCHEDULE:
-						sendToActionBar(p, color2 + TimeMode.getVillagerTime(p, color1, color2));
-						break;
-					default: //Ignored
-				}
+			String msg = String.join(" ", fields).trim();
+			if (!msg.isEmpty()) {
+				sendToActionBar(p, msg);
 			}
 		}
 		benchmark = System.nanoTime() - benchmarkStart;

--- a/src/main/java/com/roverisadog/infohud/MessageUpdaterTask.java
+++ b/src/main/java/com/roverisadog/infohud/MessageUpdaterTask.java
@@ -57,7 +57,7 @@ public class MessageUpdaterTask implements Runnable {
 
 			PlayerCfg cfg = configManager.getCfg(p);
 
-			if (cfg.getCoordMode() == CoordMode.DISABLED && cfg.getTimeMode() == TimeMode.DISABLED) {
+			if (cfg.getCoordMode() == CoordMode.DISABLED && cfg.getDirectionMode() == DirectionMode.DISABLED && cfg.getTimeMode() == TimeMode.DISABLED) {
 				configManager.removePlayer(p);
 				continue;
 			}
@@ -88,7 +88,13 @@ public class MessageUpdaterTask implements Runnable {
 			List<String> fields = new ArrayList<>();
 			if (cfg.getCoordMode() == CoordMode.ENABLED) {
 				fields.add(color1 + "XYZ: " + color2 + CoordMode.getCoordinates(p));
-				fields.add(color1 + String.format("%-10s", getPlayerDirection(p)));
+			}
+			switch (cfg.getDirectionMode()) {
+				case DETAILED:
+					fields.add(color2 + DirectionMode.getAngularDirection(p));
+				case SIMPLE:
+					fields.add(color1 + String.format("%-10s", DirectionMode.getCardinalDirection(p)));
+					break;
 			}
 			switch (cfg.getTimeMode()) {
 				case CURRENT_TICK:
@@ -112,35 +118,6 @@ public class MessageUpdaterTask implements Runnable {
 		}
 		benchmark = System.nanoTime() - benchmarkStart;
 	}
-
-	/**
-	 * Calculates cardinal direction the player is facing.
-	 * @return Small message indicating cardinal direction and coordinate
-	 *         towards which the player is facing.
-	 */
-	private static String getPlayerDirection(Player player) {
-		//-180: Leaning left | +180: Leaning right
-		float yaw = player.getLocation().getYaw();
-		//Bring to 360 degrees (Clockwise from -X axis)
-		if (yaw < 0.0F) {
-			yaw += 360.0F;
-		}
-		//Separate into 8 sectors (Arc: 45deg), offset by 1/2 sector (Arc: 22.5deg)
-		int sector = (int) ((yaw + 22.5F) / 45F);
-		switch (sector) {
-			case 1: return "SW";
-			case 2: return "W [-X]";
-			case 3: return "NW";
-			case 4: return "N [-Z]";
-			case 5: return "NE";
-			case 6: return "E [+X]";
-			case 7: return "SE";
-			case 0:
-			default: //Example: (359 + 22.5)/45
-				return "S [+Z]";
-		}
-	}
-
 
 	/**
 	 * Sends a message to a player's actionbar using {@link ActionBarSender}

--- a/src/main/java/com/roverisadog/infohud/config/ConfigManager.java
+++ b/src/main/java/com/roverisadog/infohud/config/ConfigManager.java
@@ -160,6 +160,34 @@ public class ConfigManager {
 		return true;
 	}
 
+	/* ---------------------------------- Direction Mode ---------------------------------- */
+
+	/**
+	 * Gets the direction display setting for a player.
+	 * @param p Concerned player
+	 * @return Direction display setting
+	 */
+	public DirectionMode getDirectionMode(Player p) {
+		return playerMap.get(p.getUniqueId()).getDirectionMode();
+	}
+
+	/**
+	 * Changes the direction display setting for a player and writes changes to file.
+	 * @param p Concerned player.
+	 * @param newMode New direction display setting.
+	 * @return True if successful.
+	 */
+	public synchronized boolean setDirectionMode(Player p, DirectionMode newMode) {
+		if (!isEnabled(p)) return false;
+		playerMap.get(p.getUniqueId()).setDirectionMode(newMode);
+
+		// Writes changes into config.yml
+		String playerPath = PLAYER_CFG_PATH + "." + p.getUniqueId();
+		playersConfig.set(playerPath, getCfg(p).toRawMap());
+		savePlayersConfig();
+		return true;
+	}
+
 	/* ---------------------------------- Time Mode ---------------------------------- */
 
 	/**

--- a/src/main/java/com/roverisadog/infohud/config/DirectionMode.java
+++ b/src/main/java/com/roverisadog/infohud/config/DirectionMode.java
@@ -1,0 +1,93 @@
+package com.roverisadog.infohud.config;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public enum DirectionMode {
+
+	DISABLED(0, "disabled", "disabled"),
+	SIMPLE(1, "simple", "simple"),
+	DETAILED(2, "detailed", "detailed");
+
+	public static final List<String> OPTIONS_LIST = Arrays.stream(DirectionMode.values())
+			.map(DirectionMode::toString)
+			.collect(Collectors.toList());
+	public static final String cmdName = "direction";
+	public static final String cfgKey = "directionMode";
+
+	public final int id;
+	public final String name;
+	public final String description;
+
+	DirectionMode(int id, String name, String description) {
+		this.id = id;
+		this.name = name;
+		this.description = description;
+	}
+
+	/**
+	 * Gets the direction mode enum value from a name.
+	 * @param name Name of the direction mode.
+	 * @return Enum value.
+	 * @throws NullPointerException If unknown name.
+	 */
+	public static DirectionMode get(String name) throws NullPointerException {
+		for (DirectionMode dm : DirectionMode.values()) {
+			if (dm.name.equalsIgnoreCase(name)) {
+				return dm;
+			}
+		}
+		throw new NullPointerException();
+	}
+
+	/**
+	 * Gets the string representation of the direction mode.
+	 * @return Name.
+	 */
+	@Override
+	public String toString() {
+		return name;
+	}
+
+	/**
+	 * Get a string representing the cardinal direction the player is facing.
+	 * @param player Player.
+	 * @return String representing the player's facing direction.
+	 */
+	public static String getCardinalDirection(Player player) {
+		//-180: Leaning left | +180: Leaning right
+		float yaw = player.getLocation().getYaw();
+		//Bring to 360 degrees (Clockwise from -X axis)
+		if (yaw < 0.0F) {
+			yaw += 360.0F;
+		}
+		//Separate into 8 sectors (Arc: 45deg), offset by 1/2 sector (Arc: 22.5deg)
+		int sector = (int) ((yaw + 22.5F) / 45.0F);
+		switch (sector) {
+			case 1: return "SW";
+			case 2: return "W [-X]";
+			case 3: return "NW";
+			case 4: return "N [-Z]";
+			case 5: return "NE";
+			case 6: return "E [+X]";
+			case 7: return "SE";
+			case 0:
+			default: //Example: (359 + 22.5)/45
+				return "S [+Z]";
+		}
+	}
+
+	/**
+	 * Get a string representing the yaw and pitch of the player's gaze in degrees.
+	 * @param player Player.
+	 * @return String representing the player's yaw and pitch.
+	 */
+	public static String getAngularDirection(Player player) {
+		Location loc = player.getLocation();
+		return String.format("(%.1f / %.1f)", loc.getYaw(), loc.getPitch());
+	}
+}

--- a/src/main/java/com/roverisadog/infohud/config/PlayerCfg.java
+++ b/src/main/java/com/roverisadog/infohud/config/PlayerCfg.java
@@ -14,6 +14,8 @@ public class PlayerCfg {
 
 	/** (Persistent) How coordinates should be displayed (enum in case more modes added.) */
 	private CoordMode coordMode;
+	/** (Persistent) Direction mode setting. */
+	private DirectionMode directionMode;
 	/** (Persistent) Format to display the time in. */
 	private TimeMode timeMode;
 	/** (Persistent) Dark mode settings. */
@@ -31,18 +33,20 @@ public class PlayerCfg {
 	 * Constructor that creates default configs for a player:
 	 * <ul>
 	 *     <li>coordinatesMode: enabled</li>
+	 *     <li>directionMode: simple</li>
 	 *     <li>timeMode: clock24</li>
 	 *     <li>darkMode: auto</li>
 	 * </ul>
 	 * @param id UUID of the player.
 	 */
 	protected PlayerCfg(UUID id) {
-		this(id, CoordMode.ENABLED, TimeMode.CLOCK24, DarkMode.AUTO);
+		this(id, CoordMode.ENABLED, DirectionMode.SIMPLE, TimeMode.CLOCK24, DarkMode.AUTO);
 	}
 
-	protected PlayerCfg(UUID id, CoordMode coordMode, TimeMode timeMode, DarkMode darkMode) {
+	protected PlayerCfg(UUID id, CoordMode coordMode, DirectionMode directionMode, TimeMode timeMode, DarkMode darkMode) {
 		this.id = id;
 		this.coordMode = coordMode;
+		this.directionMode = directionMode;
 		this.timeMode = timeMode;
 		this.darkMode = darkMode;
 	}
@@ -57,6 +61,14 @@ public class PlayerCfg {
 
 	public synchronized void setCoordMode(CoordMode coordMode) {
 		this.coordMode = coordMode;
+	}
+
+	public DirectionMode getDirectionMode() {
+		return directionMode;
+	}
+
+	public synchronized void setDirectionMode(DirectionMode directionMode) {
+		this.directionMode = directionMode;
 	}
 
 	public TimeMode getTimeMode() {
@@ -106,6 +118,7 @@ public class PlayerCfg {
 	protected Map<String, Object> toRawMap() {
 		Map<String, Object> tmp = new HashMap<>();
 		tmp.put(CoordMode.cfgKey, coordMode.toString());
+		tmp.put(DirectionMode.cfgKey, directionMode.toString());
 		tmp.put(TimeMode.cfgKey, timeMode.toString());
 		tmp.put(DarkMode.cfgKey, darkMode.toString());
 		return tmp;
@@ -121,23 +134,26 @@ public class PlayerCfg {
 	public static PlayerCfg fromRawMap(UUID id, Map<String, Object> map) {
 
 		CoordMode coordMode;
+		DirectionMode directionMode;
 		TimeMode timeMode;
 		DarkMode darkMode;
 
 		//Is from a version before InfoHUD 1.2 (Stored as int)
 		if (map.get(CoordMode.cfgKey) instanceof Integer) {
 			coordMode = CoordMode.get((int) map.get(CoordMode.cfgKey));
+			directionMode = DirectionMode.SIMPLE;
 			timeMode = TimeMode.get((int) map.get(TimeMode.cfgKey));
 			darkMode = DarkMode.get((int) map.get(DarkMode.cfgKey));
 		}
 		//Is from newer versions (stored as String)
 		else {
 			coordMode = CoordMode.get((String) map.get(CoordMode.cfgKey));
+			directionMode = DirectionMode.get((String) map.getOrDefault(DirectionMode.cfgKey, DirectionMode.SIMPLE.name));
 			timeMode = TimeMode.get((String) map.get(TimeMode.cfgKey));
 			darkMode = DarkMode.get((String) map.get(DarkMode.cfgKey));
 		}
 
-		return new PlayerCfg(id, coordMode, timeMode, darkMode);
+		return new PlayerCfg(id, coordMode, directionMode, timeMode, darkMode);
 	}
 
 }


### PR DESCRIPTION
InfoHUD's coordinate overlay is very helpful while flying around with elytra, but I've still found myself pressing F3 to view my pitch and yaw when land isn't in sight. These changes split the direction display into its own mode and add a more detailed setting which shows the player's yaw and pitch in the same format as the debug screen. This also allows the direction display to be turned off entirely.

Here's a screenshot with the new mode enabled:
![2023-01-30T23:58:46Z](https://user-images.githubusercontent.com/13406041/215624230-9b2ce68c-dd39-4859-99d4-bfc28f26c0ba.png)
